### PR TITLE
fix install INCLUDE path

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,10 +25,12 @@ else()
   set(CVSTEER_IS_MOBILE FALSE)
 endif()
 
-
-hunter_add_package(check_ci_tag)
-find_package(check_ci_tag CONFIG REQUIRED)
-check_ci_tag()
+option(CVSTEER_CHECK_CI_TAG "Check project vs git tag consistency" OFF)
+if(CVSTEER_CHECK_CI_TAG)
+  hunter_add_package(check_ci_tag)
+  find_package(check_ci_tag CONFIG REQUIRED)
+  check_ci_tag()
+endif()
 
 ## #################################################################
 ## Dependencies - OpenCV

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,7 +10,7 @@ HunterGate(
   SHA1 "9e103596184adb7206430047375a07eb1fa6a9b4"
 )
   
-project(cvsteer VERSION 0.1.1)
+project(cvsteer VERSION 0.1.2)
 
 set(CVSTEER_ROOT_DIR "${CMAKE_CURRENT_LIST_DIR}")
 
@@ -24,6 +24,11 @@ if(IOS OR ANDROID)
 else()
   set(CVSTEER_IS_MOBILE FALSE)
 endif()
+
+
+hunter_add_package(check_ci_tag)
+find_package(check_ci_tag CONFIG REQUIRED)
+check_ci_tag()
 
 ## #################################################################
 ## Dependencies - OpenCV

--- a/cvsteer/CMakeLists.txt
+++ b/cvsteer/CMakeLists.txt
@@ -37,7 +37,7 @@ install(
     LIBRARY DESTINATION "lib"
     ARCHIVE DESTINATION "lib"
     RUNTIME DESTINATION "bin"
-    INCLUDES DESTINATION "${include_install_dir}/${PROJECT_NAME}"
+    INCLUDES DESTINATION "${include_install_dir}"
 )
 
 install(


### PR DESCRIPTION
Usage:

#include <cvsteer/SteerableFiltersG2.h>

needs :

INCLUDES DESTINATION "${include_install_dir}"

not:

INCLUDES DESTINATION "${include_install_dir}/${PROJECT_NAME}”